### PR TITLE
Remove ENABLE_ABM

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,6 @@ driver.SetPWM ((uint8_t*)heart);
 driver.SetState ((uint8_t*)heart);
 ```
 
-## ABM mode
-
-The libray supports the IS31FL3733 automatic breath mode in addition to the standard PWM brightness mode.
-To enable ABM support you must define `ENABLE_PWM` at compile time. For PlatformIO builds add the following
-to each platform in the `platformio.ini` file:
-
-```yaml
-build_flags =
-    -DENABLE_ABM
-```
-
 ### Initializing ABM mode, setting parameters, and starting ABM
 
 To set up ABM mode first turn on the desired LEDs, then set the LED mode to one of the available

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -116,9 +116,6 @@ namespace IS31FL3733
     RESISTOR_32K = 0x07  //< 32 kOhm pull-up resistor.
   };
 
-// ****************************************************************
-// Start ABM support
-#ifdef ENABLE_ABM
   /// @brief Maximum number of ABM loop times.
   const int ABM_LOOP_TIMES_MAX = 0x0FFF;
 
@@ -225,10 +222,6 @@ namespace IS31FL3733
     ABM_LOOP_END Tend;     ///< Position in sequence where loop ends.
     uint16_t Times;        ///< Number of times to loop. Set to ABM_LOOP_FOREVER to loop forever.
   };
-
-#endif
-  // End ABW support
-  // ****************************************************************
 
   /// @brief Function definition for reading and writing the registers.
   typedef uint8_t (*i2c_function)(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *buffer, uint8_t count);
@@ -343,8 +336,6 @@ namespace IS31FL3733
     /// @param states An array of PWM values for all 192 LEDs.
     void SetPWM(uint8_t *values);
 
-// ABM functions
-#ifdef ENABLE_ABM
     /// @brief Sets the LED operating mode for an LED.
     /// @param cs The LED's column position. Use CS_COUNT to set all LEDs in the column.
     /// @param sw The LED's row position. Use SW_COUNT to set all LEDs in the row.
@@ -358,6 +349,5 @@ namespace IS31FL3733
 
     /// @brief Starts ABM operation.
     void StartABM();
-#endif
   };
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,8 +20,6 @@
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-build_flags =
-	-DENABLE_ABM
 monitor_speed = 115200
 extra_scripts = 
 	pre:get_version.py
@@ -30,8 +28,6 @@ extra_scripts =
 platform = atmelavr
 board = sparkfun_promicro16
 framework = arduino
-build_flags =
-	-DENABLE_ABM
 monitor_speed = 115200
 extra_scripts = 
 	pre:get_version.py

--- a/src/is31fl3733.cpp
+++ b/src/is31fl3733.cpp
@@ -341,7 +341,6 @@ namespace IS31FL3733
     WritePagedRegs(PAGEDREGISTER::LEDPWM, values, SW_LINES * CS_LINES);
   }
 
-#ifdef ENABLE_ABM
   void IS31FL3733Driver::SetLEDMode(uint8_t cs, uint8_t sw, LED_MODE mode)
   {
     uint8_t offset;
@@ -422,5 +421,4 @@ namespace IS31FL3733
     // Write 0x00 to Time Update Register to update ABM settings.
     WritePagedReg(PAGEDREGISTER::TUR, 0x00);
   }
-#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,23 +69,23 @@ void setup()
   Serial.println("Turning on all LEDs");
   driver.SetLEDState(CS_LINES, SW_LINES, LED_STATE::ON);
 
-  // Serial.println("Configure all LEDs for ABM1");
-  // driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
+  Serial.println("Configure all LEDs for ABM1");
+  driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
 
-  // ABM_CONFIG ABM1;
+  ABM_CONFIG ABM1;
 
-  // ABM1.T1 = ABM_T1::T1_840MS;
-  // ABM1.T2 = ABM_T2::T2_840MS;
-  // ABM1.T3 = ABM_T3::T3_840MS;
-  // ABM1.T4 = ABM_T4::T4_840MS;
-  // ABM1.Tbegin = ABM_LOOP_BEGIN::LOOP_BEGIN_T4;
-  // ABM1.Tend = ABM_LOOP_END::LOOP_END_T3;
-  // ABM1.Times = ABM_LOOP_FOREVER;
+  ABM1.T1 = ABM_T1::T1_840MS;
+  ABM1.T2 = ABM_T2::T2_840MS;
+  ABM1.T3 = ABM_T3::T3_840MS;
+  ABM1.T4 = ABM_T4::T4_840MS;
+  ABM1.Tbegin = ABM_LOOP_BEGIN::LOOP_BEGIN_T4;
+  ABM1.Tend = ABM_LOOP_END::LOOP_END_T3;
+  ABM1.Times = ABM_LOOP_FOREVER;
 
-  // // Write ABM structure parameters to device registers.
-  // driver.ConfigABM(ABM_NUM::NUM_1, &ABM1);
-  // // Start ABM mode operation.
-  // driver.StartABM();
+  // Write ABM structure parameters to device registers.
+  driver.ConfigABM(ABM_NUM::NUM_1, &ABM1);
+  // Start ABM mode operation.
+  driver.StartABM();
 }
 
 void loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,23 +69,23 @@ void setup()
   Serial.println("Turning on all LEDs");
   driver.SetLEDState(CS_LINES, SW_LINES, LED_STATE::ON);
 
-  Serial.println("Configure all LEDs for ABM1");
-  driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
+  // Serial.println("Configure all LEDs for ABM1");
+  // driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
 
-  ABM_CONFIG ABM1;
+  // ABM_CONFIG ABM1;
 
-  ABM1.T1 = ABM_T1::T1_840MS;
-  ABM1.T2 = ABM_T2::T2_840MS;
-  ABM1.T3 = ABM_T3::T3_840MS;
-  ABM1.T4 = ABM_T4::T4_840MS;
-  ABM1.Tbegin = ABM_LOOP_BEGIN::LOOP_BEGIN_T4;
-  ABM1.Tend = ABM_LOOP_END::LOOP_END_T3;
-  ABM1.Times = ABM_LOOP_FOREVER;
+  // ABM1.T1 = ABM_T1::T1_840MS;
+  // ABM1.T2 = ABM_T2::T2_840MS;
+  // ABM1.T3 = ABM_T3::T3_840MS;
+  // ABM1.T4 = ABM_T4::T4_840MS;
+  // ABM1.Tbegin = ABM_LOOP_BEGIN::LOOP_BEGIN_T4;
+  // ABM1.Tend = ABM_LOOP_END::LOOP_END_T3;
+  // ABM1.Times = ABM_LOOP_FOREVER;
 
-  // Write ABM structure parameters to device registers.
-  driver.ConfigABM(ABM_NUM::NUM_1, &ABM1);
-  // Start ABM mode operation.
-  driver.StartABM();
+  // // Write ABM structure parameters to device registers.
+  // driver.ConfigABM(ABM_NUM::NUM_1, &ABM1);
+  // // Start ABM mode operation.
+  // driver.StartABM();
 }
 
 void loop()


### PR DESCRIPTION
Fixes #11

Compilers can optimize unused code away so there's no need to ifdef ABM support to get a smaller size.