### PR TITLE
Refactor and simplify all the things

### DIFF
--- a/examples/abm_arduino.cpp
+++ b/examples/abm_arduino.cpp
@@ -132,23 +132,14 @@ void setup()
   Serial.println("Setting global current control to half");
   driver.SetGCC(127);
 
-  Serial.println("Setting PWM state for all LEDs to full power in 5 seconds...");
-  delay(5000);
-  driver.SetLEDMatrixPWM(255);
-  Serial.println("Done");
-  delay(5000);
-
-  Serial.println("Setting PWM state for all LEDs to half power in 5 seconds...");
-  delay(5000);
+  Serial.println("Setting PWM state for all LEDs to half power");
   driver.SetLEDMatrixPWM(128);
-  Serial.println("Done");
-  delay(5000);
 
   Serial.println("Turning on all LEDs");
   driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");
-  driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
+  driver.SetLEDMatrixMode(LED_MODE::ABM1);
 
   ABM_CONFIG ABM1;
 
@@ -202,7 +193,7 @@ void loop()
     {
       Serial.println("ABM1 completed");
       Serial.println("Configure all LEDs for full on");
-      driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::PWM);
+      driver.SetLEDMatrixMode(LED_MODE::PWM);
 
       ledState = LedState::LEDOn;
     }

--- a/examples/abm_arduino.cpp
+++ b/examples/abm_arduino.cpp
@@ -135,7 +135,7 @@ void setup()
   Serial.println("Setting PWM state for all LEDs to half power");
   driver.SetLEDMatrixPWM(128);
 
-  Serial.println("Turning on all LEDs");
+  Serial.println("Setting state of all LEDs to ON");
   driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");

--- a/examples/abm_arduino.cpp
+++ b/examples/abm_arduino.cpp
@@ -9,7 +9,6 @@
  * @copyright Copyright (c) 2021
  * 
  */
-
 #include <Arduino.h>
 #include <Wire.h>
 
@@ -20,7 +19,7 @@ using namespace IS31FL3733;
 // Arduino pin for the SDB line which is set high to enable the IS31FL3733 chip.
 const uint8_t SDB_PIN = 4;
 // Arduino pin for the IS13FL3733 interrupt pin.
-const uint8_t INTB_PIN = 7;
+const uint8_t INTB_PIN = 3;
 
 // Function prototypes for the read and write functions defined later in the file.
 uint8_t i2c_read_reg(const uint8_t i2c_addr, const uint8_t reg_addr, uint8_t *buffer, const uint8_t length);
@@ -71,22 +70,22 @@ uint8_t i2c_read_reg(const uint8_t i2c_addr, const uint8_t reg_addr, uint8_t *bu
 }
 
 /**
- * @brief Writes a buffer to the specified register.
+ * @brief Writes a buffer to the specified register. It is up to the caller to ensure the count of
+ * bytes to write doesn't exceed 31, which is the Arduino's write buffer size (32) minus one byte for
+ * the register address.
  * 
  * @param i2c_addr I2C address of the device to write the data to.
  * @param reg_addr Address of the register to write to.
  * @param buffer Pointer to an array of bytes to write.
  * @param count Number of bytes in the buffer.
- * @return uint8_t The number of bytes written.
+ * @return uint8_t 0 if success, non-zero on error.
  */
 uint8_t i2c_write_reg(const uint8_t i2c_addr, const uint8_t reg_addr, const uint8_t *buffer, const uint8_t count)
 {
   Wire.beginTransmission(i2c_addr);
   Wire.write(reg_addr);
-  byte bytesWritten = Wire.write(buffer, count);
-  Wire.endTransmission();
-
-  return bytesWritten;
+  Wire.write(buffer, count);
+  return Wire.endTransmission();
 }
 
 /**
@@ -133,11 +132,20 @@ void setup()
   Serial.println("Setting global current control to half");
   driver.SetGCC(127);
 
-  Serial.println("Setting PWM state for all LEDs to full power");
-  driver.SetLEDPWM(CS_LINES, SW_LINES, 255);
+  Serial.println("Setting PWM state for all LEDs to full power in 5 seconds...");
+  delay(5000);
+  driver.SetLEDMatrixPWM(255);
+  Serial.println("Done");
+  delay(5000);
+
+  Serial.println("Setting PWM state for all LEDs to half power in 5 seconds...");
+  delay(5000);
+  driver.SetLEDMatrixPWM(128);
+  Serial.println("Done");
+  delay(5000);
 
   Serial.println("Turning on all LEDs");
-  driver.SetLEDState(CS_LINES, SW_LINES, LED_STATE::ON);
+  driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");
   driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -238,6 +238,11 @@ namespace IS31FL3733
     i2c_write_function i2c_write_reg;      ///< Pointer to the i2C write register function.
     uint8_t leds[SW_LINES * CS_LINES / 8]; ///< State of individual LEDs. Bitmask that can't be read back from IS31FL3733.
 
+    /// @brief Writes every byte in the specified paged register with the specified value.
+    /// @param reg The register to write to.
+    /// @param value The value to write.
+    void _setFullPagedRegister(const PAGEDREGISTER reg, const uint8_t value);
+
   public:
     /// @brief Construct a new IS31FL3733 object
     /// @param addr1 The ADDR1 pin connection. Must be a value from the ADDR enum.

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -238,10 +238,22 @@ namespace IS31FL3733
     i2c_write_function i2c_write_reg;      ///< Pointer to the i2C write register function.
     uint8_t leds[SW_LINES * CS_LINES / 8]; ///< State of individual LEDs. Bitmask that can't be read back from IS31FL3733.
 
+    /// @brief Writes every byte in the specified column of the paged register with the specified value.
+    /// @param reg The register to write to.
+    /// @param sw The column to write to. Origin 0, for example pass 0 to write to cs1.
+    /// @param value The value to write.
+    void _setColumnPagedRegister(const PAGEDREGISTER reg, const uint8_t cs, uint8_t value);
+
     /// @brief Writes every byte in the specified paged register with the specified value.
     /// @param reg The register to write to.
     /// @param value The value to write.
     void _setFullPagedRegister(const PAGEDREGISTER reg, const uint8_t value);
+
+    /// @brief Writes every byte in the specified row of the paged register with the specified value.
+    /// @param reg The register to write to.
+    /// @param sw The row to write to. Origin 0, for example pass 0 to write to sw1.
+    /// @param value The value to write.
+    void _setRowPagedRegister(const PAGEDREGISTER reg, const uint8_t sw, uint8_t value);
 
   public:
     /// @brief Construct a new IS31FL3733 object
@@ -358,7 +370,7 @@ namespace IS31FL3733
 
     /// @brief Set the LED state for all LED's from buffer.
     /// @param states An array of LED states for all 192 LEDs.
-    void SetState(const uint8_t *states);
+    void SetState(const LED_STATE *states);
 
     /// @brief Get the status of an LED.
     /// @param CS The LED's column position.

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -255,6 +255,12 @@ namespace IS31FL3733
     /// @param value The value to write.
     void _setRowPagedRegister(const PAGEDREGISTER reg, const uint8_t sw, uint8_t value);
 
+    /// @brief Sets the state of an LED in a single byte of the led array.
+    /// @param offset The position in the array for the LED byte.
+    /// @param cs The LED's column position. Origin 0, for example pass 0 to control cs1.
+    /// @param state The LED_STATE to set the LED to.
+    void _setLEDState(const uint8_t offset, const uint8_t cs, const LED_STATE state);
+
   public:
     /// @brief Construct a new IS31FL3733 object
     /// @param addr1 The ADDR1 pin connection. Must be a value from the ADDR enum.

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -6,12 +6,11 @@
 #include <Arduino.h>
 #endif
 
-#include <stdint.h>
-
 namespace IS31FL3733
 {
-  const uint8_t CS_LINES = 16; ///< Number of CS lines on the chip.
-  const uint8_t SW_LINES = 12; ///< Number of SW lines on the chip.
+  const uint8_t CS_LINES = 16;                   ///< Number of CS lines on the chip.
+  const uint8_t SW_LINES = 12;                   ///< Number of SW lines on the chip.
+  const uint8_t LED_COUNT = CS_LINES * SW_LINES; ///< Total number of LEDs in the matrix.
 
   /// @brief Addresses for the common registers.
   enum COMMONREGISTER
@@ -232,6 +231,7 @@ namespace IS31FL3733
   {
   private:
     const uint8_t I2C_BASE_ADDR = 0xA0; ///< Base I2C address of the chip.
+    uint8_t maxI2CWriteBufferSize;      ///< Maximum number of bytes that can be written by i2c_write_buffer in a single call.
 
     uint8_t address;                       ///< Address on I2C bus.
     i2c_read_function i2c_read_reg;        ///< Pointer to I2C read register function.
@@ -311,27 +311,55 @@ namespace IS31FL3733
     /// @param resistor The value of the pull-down resistor to use.
     void SetCSPDR(const RESISTOR resistor);
 
-    /// @brief Set LED state to either ON or OFF.
-    /// @param cs The LED's column position. Use CS_COUNT to set all LEDs in the column.
-    /// @param sw The LED's row position. Use SW_COUNT to set all LEDs in the row.
+    /// @brief Set a single LED state to either ON or OFF.
+    /// @param cs The LED's column position. Origin 0, for example pass 0 to control cs1.
+    /// @param sw The LED's row position. Origin 0, for example pass 0 to control sw1.
     /// @param state The LED_STATE to set the LED to.
-    void SetLEDState(uint8_t cs, uint8_t sw, const LED_STATE state);
+    void SetLEDSingleState(const uint8_t cs, const uint8_t sw, const LED_STATE state);
 
-    /// @brief Set the LED PWM duty value.
-    /// @param cs The LED's column position. Use CS_COUNT to set all LEDs in the column.
-    /// @param sw The LED's row position. Use SW_COUNT to set all LEDs in the row.
+    /// @brief Sets all LEDs in the specified column to either ON or OFF.
+    /// @param cs The column to set. Origin 0, for example pass 0 to control cs1.
+    /// @param state The LED_STATE to set the LEDs to.
+    void SetLEDColumnState(uint8_t cs, const LED_STATE state);
+
+    /// @brief Sets all LEDs in the specified row to either ON or OFF.
+    /// @param sw The row to set. Origin 0, for example pass 0 to control sw1.
+    /// @param state The LED_STATE to set the LEDs to.
+    void SetLEDRowState(uint8_t sw, const LED_STATE state);
+
+    /// @brief Sets all LEDs to either ON or OFF.
+    /// @param cs The column to set. Origin 0, for example pass 0 to control cs1.    /// @param state The LED_STATE to set the LEDs to.
+    void SetLEDMatrixState(const LED_STATE state);
+
+    /// @brief Set the PWM duty value for a single LED.
+    /// @param cs The LED's column position. Origin 0, for example pass 0 to control cs1.
+    /// @param sw The LED's row position. Origin 0, for example pass 0 to control sw1.
     /// @param value The PWM duty cycle to set the LED to.
-    void SetLEDPWM(uint8_t cs, uint8_t sw, const uint8_t value);
+    void SetLEDSinglePWM(const uint8_t cs, const uint8_t sw, const uint8_t value);
+
+    /// @brief Set the PWM duty value for all LEDs in a column.
+    /// @param cs The column to set. Origin 0, for example pass 0 to control cs1.
+    /// @param value The PWM duty cycle to set the LEDs to.
+    void SetLEDColumnPWM(const uint8_t cs, const uint8_t value);
+
+    /// @brief Set the PWM duty value for all LEDs in a row.
+    /// @param sw The row to set. Origin 0, for example pass 0 to control sw1.
+    /// @param value The PWM duty cycle to set the LEDs to.
+    void SetLEDRowPWM(const uint8_t sw, const uint8_t value);
+
+    /// @brief Set the PWM duty value for all LEDs.
+    /// @param value The PWM duty cycle to set the LEDs to.
+    void SetLEDMatrixPWM(const uint8_t value);
+
+    /// @brief Set the LED state for all LED's from buffer.
+    /// @param states An array of LED states for all 192 LEDs.
+    void SetState(const uint8_t *states);
 
     /// @brief Get the status of an LED.
     /// @param CS The LED's column position.
     /// @param SW THe LED's row position.
     /// @returns The status of the LED.
     LED_STATUS GetLEDStatus(const uint8_t cs, const uint8_t sw);
-
-    /// @brief Set the LED state for all LED's from buffer.
-    /// @param states An array of LED states for all 192 LEDs.
-    void SetState(const uint8_t *states);
 
     /// @brief Set the LED PWN values for all LED's from buffer.
     /// @param states An array of PWM values for all 192 LEDs.

--- a/include/is31fl3733.hpp
+++ b/include/is31fl3733.hpp
@@ -365,11 +365,25 @@ namespace IS31FL3733
     /// @param states An array of PWM values for all 192 LEDs.
     void SetPWM(const uint8_t *values);
 
-    /// @brief Sets the LED operating mode for an LED.
-    /// @param cs The LED's column position. Use CS_COUNT to set all LEDs in the column.
-    /// @param sw The LED's row position. Use SW_COUNT to set all LEDs in the row.
+    /// @brief Sets the LED operating mode for a single LED.
+    /// @param cs The LED's column position. Origin 0, for example pass 0 to control cs1.
+    /// @param sw The LED's row position. Origin 0, for example pass 0 to control sw1.
     /// @param value The LED_MODE to set.
-    void SetLEDMode(uint8_t cs, uint8_t sw, const LED_MODE mode);
+    void SetLEDSingleMode(uint8_t cs, uint8_t sw, const LED_MODE mode);
+
+    /// @brief Set the LED operating mode for all LEDs in a row.
+    /// @param sw The row to set. Origin 0, for example pass 0 to control sw1.
+    /// @param value The LED_MODE to set.
+    void SetLEDRowMode(const uint8_t sw, const LED_MODE mode);
+
+    /// @brief Set the LED operating mode for all LEDs in a column.
+    /// @param sw The column to set. Origin 0, for example pass 0 to control cs1.
+    /// @param value The LED_MODE to set.
+    void SetLEDColumnMode(const uint8_t cs, const LED_MODE mode);
+
+    /// @brief Set the LED operating mode for all LEDs in the matrix.
+    /// @param value The LED_MODE to set.
+    void SetLEDMatrixMode(const LED_MODE mode);
 
     /// @brief Configures the ABM mode options.
     /// @param n The ABM to configure.

--- a/src/is31fl3733.cpp
+++ b/src/is31fl3733.cpp
@@ -2,13 +2,19 @@
 
 namespace IS31FL3733
 {
-  IS31FL3733Driver::IS31FL3733Driver(const ADDR addr1, const ADDR addr2,const i2c_read_function read_function,const i2c_write_function write_function)
+  IS31FL3733Driver::IS31FL3733Driver(const ADDR addr1, const ADDR addr2, const i2c_read_function read_function, const i2c_write_function write_function)
   {
 #ifdef ARDUINO
     // Arduino uses 7 bit I2C addresses without the R/W bit in position 0.
     address = ((I2C_BASE_ADDR) | ((addr2) << 3) | ((addr1) << 1)) >> 1;
+    // Arduino's Wire.write() function is limited to 32 bytes in one go.
+    // This is set to 31 because one of the bytes gets consumed by the register address
+    // getting written to.
+    maxI2CWriteBufferSize = 31;
 #else
     address = ((I2C_BASE_ADDR) | ((addr2) << 3) | ((addr1) << 1));
+    // For all other platforms assume it is possible to write a full page at once.
+    maxI2CWriteBufferSize = LED_COUNT;
 #endif
 
     i2c_read_reg = read_function;
@@ -79,11 +85,28 @@ namespace IS31FL3733
 
   void IS31FL3733Driver::WritePagedRegs(const PAGEDREGISTER reg, const uint8_t offset, const uint8_t *values, const uint8_t count)
   {
-    // Select registers page.
-    SelectPageForRegister(reg);
-    // Write values to registers.
-    // The register is the low eight bits of the reg_addr.
-    i2c_write_reg(address, (uint8_t)(reg) + offset, values, count);
+    uint8_t bytesRemaining = count;
+    uint8_t bytesToWrite = maxI2CWriteBufferSize;
+    uint8_t bytesWritten = 0;
+
+    // Depending on the platform it may not be possible to send the entire list of values at once.
+    while (bytesRemaining > 0)
+    {
+      if (bytesRemaining < maxI2CWriteBufferSize)
+      {
+        bytesToWrite = bytesRemaining;
+      }
+
+      // Select register page.
+      SelectPageForRegister(reg);
+
+      // Write values to registers.
+      // The register is the low eight bits of the reg_addr.
+      i2c_write_reg(address, (uint8_t)(reg) + offset + bytesWritten, &values[bytesWritten], bytesToWrite);
+
+      bytesRemaining -= bytesToWrite;
+      bytesWritten += bytesToWrite;
+    }
   }
 
   void IS31FL3733Driver::Init()
@@ -93,7 +116,7 @@ namespace IS31FL3733
     // Clear software reset in configuration register.
     WritePagedReg(PAGEDREGISTER::CR, CR_OPTIONS::CR_SSD);
     // Clear state of all LEDs in internal buffer and sync buffer to device.
-    SetLEDState(CS_LINES, SW_LINES, LED_STATE::OFF);
+    SetLEDMatrixState(LED_STATE::OFF);
   }
 
   byte IS31FL3733Driver::GetI2CAddress()
@@ -119,162 +142,149 @@ namespace IS31FL3733
     WritePagedReg(PAGEDREGISTER::CSPDR, resistor);
   }
 
-  void IS31FL3733Driver::SetLEDState(uint8_t cs, uint8_t sw, const LED_STATE state)
+  void IS31FL3733Driver::SetLEDSingleState(const uint8_t cs, uint8_t sw, const LED_STATE state)
   {
     uint8_t offset;
 
-    // Check SW boundaries.
-    if (sw < SW_LINES)
+    // Set state of individual LED.
+    // Calculate LED bit offset.
+    offset = (sw << 1) + (cs / 8);
+
+    // Update state of LED in internal buffer.
+    if (state == LED_STATE::OFF)
     {
-      // Check CS boundaries.
-      if (cs < CS_LINES)
-      {
-        // Set state of individual LED.
-        // Calculate LED bit offset.
-        offset = (sw << 1) + (cs / 8);
-        // Update state of LED in internal buffer.
-        if (state == LED_STATE::OFF)
-        {
-          // Clear bit for selected LED.
-          leds[offset] &= ~(0x01 << (cs % 8));
-        }
-        else
-        {
-          // Set bit for selected LED.
-          leds[offset] |= 0x01 << (cs % 8);
-        }
-        // Write updated LED state to device register.
-        WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
-      }
-      else
-      {
-        // Set state of full row selected by SW.
-        // Calculate row offset.
-        offset = sw << 1;
-        // Update state of row LEDs in internal buffer.
-        if (state == LED_STATE::OFF)
-        {
-          // Clear 16 bits for selected row LEDs.
-          leds[offset] = 0x00;
-          leds[offset + 1] = 0x00;
-        }
-        else
-        {
-          // Set 16 bits for selected row LEDs.
-          leds[offset] = 0xFF;
-          leds[offset + 1] = 0xFF;
-        }
-        // Write updated LEDs state to device registers.
-        WritePagedRegs(PAGEDREGISTER::LEDONOFF, offset, &leds[offset], CS_LINES / 8);
-      }
+      // Clear bit for selected LED.
+      leds[offset] &= ~(0x01 << (cs % 8));
     }
     else
     {
-      // Check CS boundaries.
-      if (cs < CS_LINES)
+      // Set bit for selected LED.
+      leds[offset] |= 0x01 << (cs % 8);
+    }
+
+    // Write updated LED state to device register.
+    WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
+  }
+
+  void IS31FL3733Driver::SetLEDRowState(const uint8_t sw, const LED_STATE state)
+  {
+    uint8_t offset;
+
+    // Set state of full row selected by SW.
+    // Calculate row offset.
+    offset = sw << 1;
+    // Update state of row LEDs in internal buffer.
+    if (state == LED_STATE::OFF)
+    {
+      // Clear 16 bits for selected row LEDs.
+      leds[offset] = 0x00;
+      leds[offset + 1] = 0x00;
+    }
+    else
+    {
+      // Set 16 bits for selected row LEDs.
+      leds[offset] = 0xFF;
+      leds[offset + 1] = 0xFF;
+    }
+    // Write updated LEDs state to device registers.
+    WritePagedRegs(PAGEDREGISTER::LEDONOFF, offset, &leds[offset], CS_LINES / 8);
+  }
+
+  void IS31FL3733Driver::SetLEDColumnState(const uint8_t cs, const LED_STATE state)
+  {
+    uint8_t offset;
+
+    // Set state of full column selected by CS.
+    for (uint8_t row = 0; row < SW_LINES; row++)
+    {
+      // Calculate LED bit offset.
+      offset = (row << 1) + (cs / 8);
+      // Update state of LED in internal buffer.
+      if (state == LED_STATE::OFF)
       {
-        // Set state of full column selected by CS.
-        for (sw = 0; sw < SW_LINES; sw++)
-        {
-          // Calculate LED bit offset.
-          offset = (sw << 1) + (cs / 8);
-          // Update state of LED in internal buffer.
-          if (state == LED_STATE::OFF)
-          {
-            // Clear bit for selected LED.
-            leds[offset] &= ~(0x01 << (cs % 8));
-          }
-          else
-          {
-            // Set bit for selected LED.
-            leds[offset] |= 0x01 << (cs % 8);
-          }
-          // Write updated LED state to device register.
-          WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
-        }
+        // Clear bit for selected LED.
+        leds[offset] &= ~(0x01 << (cs % 8));
       }
       else
       {
-        // Set state of all LEDs.
-        for (sw = 0; sw < SW_LINES; sw++)
-        {
-          // Update state of all LEDs in internal buffer.
-          if (state == LED_STATE::OFF)
-          {
-            // Clear all bits.
-            leds[(sw << 1)] = 0x00;
-            leds[(sw << 1) + 1] = 0x00;
-          }
-          else
-          {
-            // Set all bits.
-            leds[(sw << 1)] = 0xFF;
-            leds[(sw << 1) + 1] = 0xFF;
-          }
-        }
-        // Write updated LEDs state to device registers.
-        WritePagedRegs(PAGEDREGISTER::LEDONOFF, leds, SW_LINES * CS_LINES / 8);
+        // Set bit for selected LED.
+        leds[offset] |= 0x01 << (cs % 8);
       }
+      // Write updated LED state to device register.
+      WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
     }
   }
 
-  void IS31FL3733Driver::SetLEDPWM(uint8_t cs, uint8_t sw, const uint8_t value)
+  void IS31FL3733Driver::SetLEDMatrixState(const LED_STATE state)
+  {
+    for (uint8_t row = 0; row < SW_LINES; row++)
+    {
+      // Update state of all LEDs in internal buffer.
+      if (state == LED_STATE::OFF)
+      {
+        // Clear all bits.
+        leds[(row << 1)] = 0x00;
+        leds[(row << 1) + 1] = 0x00;
+      }
+      else
+      {
+        // Set all bits.
+        leds[(row << 1)] = 0xFF;
+        leds[(row << 1) + 1] = 0xFF;
+      }
+    }
+    // Write updated LEDs state to device registers.
+    WritePagedRegs(PAGEDREGISTER::LEDONOFF, leds, SW_LINES * CS_LINES / 8);
+  }
+
+  void IS31FL3733Driver::SetLEDSinglePWM(uint8_t cs, uint8_t sw, const uint8_t value)
   {
     uint8_t offset;
 
-    // Check SW boundaries.
-    if (sw < SW_LINES)
+    // Calculate LED offset.
+    offset = sw * CS_LINES + cs;
+    // Write LED PWM value to device register.
+    WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
+  }
+
+  void IS31FL3733Driver::SetLEDRowPWM(uint8_t sw, const uint8_t value)
+  {
+    uint8_t values[CS_LINES];
+
+    memset(values, value, CS_LINES * sizeof(uint8_t));
+
+    // Write LED PWM value to device register.
+    WritePagedRegs(PAGEDREGISTER::LEDPWM, sw * CS_LINES, values, CS_LINES);
+  }
+
+  void IS31FL3733Driver::SetLEDColumnPWM(uint8_t cs, const uint8_t value)
+  {
+    uint8_t offset;
+
+    // Set PWM of full column selected by CS.
+    for (uint8_t row = 0; row < SW_LINES; row++)
     {
-      // Check CS boundaries.
-      if (cs < CS_LINES)
-      {
-        // Set PWM of individual LED.
-        // Calculate LED offset.
-        offset = sw * CS_LINES + cs;
-        // Write LED PWM value to device register.
-        WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
-      }
-      else
-      {
-        // Set PWM of full row selected by SW.
-        for (cs = 0; cs < CS_LINES; cs++)
-        {
-          // Calculate LED offset.
-          offset = sw * CS_LINES + cs;
-          // Write LED PWM value to device register.
-          WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
-        }
-      }
+      // Calculate LED offset.
+      offset = row * CS_LINES + cs;
+
+      // Write LED PWM value to device register.
+      WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
     }
-    else
-    {
-      // Check CS boundaries.
-      if (cs < CS_LINES)
-      {
-        // Set PWM of full column selected by CS.
-        for (sw = 0; sw < SW_LINES; sw++)
-        {
-          // Calculate LED offset.
-          offset = sw * CS_LINES + cs;
-          // Write LED PWM value to device register.
-          WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
-        }
-      }
-      else
-      {
-        // Set PWM of all LEDs.
-        for (sw = 0; sw < SW_LINES; sw++)
-        {
-          for (cs = 0; cs < CS_LINES; cs++)
-          {
-            // Calculate LED offset.
-            offset = sw * CS_LINES + cs;
-            // Write LED PWM value to device register.
-            WritePagedReg(PAGEDREGISTER::LEDPWM, offset, value);
-          }
-        }
-      }
-    }
+  }
+
+  void IS31FL3733Driver::SetLEDMatrixPWM(const uint8_t value)
+  {
+    // On Arduino the maximum buffer size for an I2C write is 32 bytes so this is
+    // really wasting RAM on the Arduino. Ideally on Arduino this would only be 32
+    // bytes and would get sent repeatedly until LED_COUNT's worth of bytes are sent.
+    // The downside to that approach is this code is no longer portable across
+    // platforms. So instead this is the full amount of bytes that have to get sent
+    // and splitting it into appropriate chunks is left to WritePagedRegs().
+    uint8_t values[LED_COUNT];
+
+    memset(values, value, LED_COUNT * sizeof(uint8_t));
+
+    WritePagedRegs(PAGEDREGISTER::LEDPWM, values, LED_COUNT);
   }
 
   LED_STATUS IS31FL3733Driver::GetLEDStatus(uint8_t cs, uint8_t sw)

--- a/src/is31fl3733.cpp
+++ b/src/is31fl3733.cpp
@@ -21,6 +21,21 @@ namespace IS31FL3733
     i2c_write_reg = write_function;
   }
 
+  void IS31FL3733Driver::_setFullPagedRegister(const PAGEDREGISTER reg, uint8_t value)
+  {
+    // On Arduino the maximum buffer size for an I2C write is 32 bytes so this is
+    // really wasting RAM on the Arduino. Ideally on Arduino this would only be 32
+    // bytes and would get sent repeatedly until LED_COUNT's worth of bytes are sent.
+    // The downside to that approach is this code is no longer portable across
+    // platforms. So instead this is the full amount of bytes that have to get sent
+    // and splitting it into appropriate chunks is left to WritePagedRegs().
+    uint8_t values[LED_COUNT];
+
+    memset(values, value, LED_COUNT * sizeof(uint8_t));
+
+    WritePagedRegs(reg, values, LED_COUNT);
+  }
+
   uint8_t IS31FL3733Driver::ReadCommonReg(const COMMONREGISTER reg)
   {
     uint8_t reg_value;
@@ -270,17 +285,7 @@ namespace IS31FL3733
 
   void IS31FL3733Driver::SetLEDMatrixPWM(const uint8_t value)
   {
-    // On Arduino the maximum buffer size for an I2C write is 32 bytes so this is
-    // really wasting RAM on the Arduino. Ideally on Arduino this would only be 32
-    // bytes and would get sent repeatedly until LED_COUNT's worth of bytes are sent.
-    // The downside to that approach is this code is no longer portable across
-    // platforms. So instead this is the full amount of bytes that have to get sent
-    // and splitting it into appropriate chunks is left to WritePagedRegs().
-    uint8_t values[LED_COUNT];
-
-    memset(values, value, LED_COUNT * sizeof(uint8_t));
-
-    WritePagedRegs(PAGEDREGISTER::LEDPWM, values, LED_COUNT);
+    _setFullPagedRegister(PAGEDREGISTER::LEDPWM, value);
   }
 
   LED_STATUS IS31FL3733Driver::GetLEDStatus(uint8_t cs, uint8_t sw)
@@ -379,17 +384,7 @@ namespace IS31FL3733
 
   void IS31FL3733Driver::SetLEDMatrixMode(const LED_MODE mode)
   {
-    // On Arduino the maximum buffer size for an I2C write is 32 bytes so this is
-    // really wasting RAM on the Arduino. Ideally on Arduino this would only be 32
-    // bytes and would get sent repeatedly until LED_COUNT's worth of bytes are sent.
-    // The downside to that approach is this code is no longer portable across
-    // platforms. So instead this is the full amount of bytes that have to get sent
-    // and splitting it into appropriate chunks is left to WritePagedRegs().
-    uint8_t modes[LED_COUNT];
-
-    memset(modes, mode, LED_COUNT * sizeof(uint8_t));
-
-    WritePagedRegs(PAGEDREGISTER::LEDABM, modes, LED_COUNT);
+    _setFullPagedRegister(PAGEDREGISTER::LEDABM, mode);
   }
 
   void IS31FL3733Driver::ConfigABM(const ABM_NUM n, const ABM_CONFIG *config)

--- a/src/is31fl3733.cpp
+++ b/src/is31fl3733.cpp
@@ -23,6 +23,21 @@ namespace IS31FL3733
     i2c_write_reg = write_function;
   }
 
+  void IS31FL3733Driver::_setLEDState(const uint8_t offset, const uint8_t cs, const LED_STATE state)
+  {
+    // Update state of LED in internal buffer.
+    if (state == LED_STATE::OFF)
+    {
+      // Clear bit for selected LED.
+      leds[offset] &= ~(0x01 << (cs % 8));
+    }
+    else
+    {
+      // Set bit for selected LED.
+      leds[offset] |= 0x01 << (cs % 8);
+    }
+  }
+
   void IS31FL3733Driver::_setColumnPagedRegister(const PAGEDREGISTER reg, const uint8_t cs, uint8_t value)
   {
     uint8_t offset;
@@ -186,17 +201,7 @@ namespace IS31FL3733
     // Calculate LED bit offset.
     offset = (sw << 1) + (cs / 8);
 
-    // Update state of LED in internal buffer.
-    if (state == LED_STATE::OFF)
-    {
-      // Clear bit for selected LED.
-      leds[offset] &= ~(0x01 << (cs % 8));
-    }
-    else
-    {
-      // Set bit for selected LED.
-      leds[offset] |= 0x01 << (cs % 8);
-    }
+    _setLEDState(offset, cs, state);
 
     WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
   }
@@ -232,17 +237,7 @@ namespace IS31FL3733
       // Calculate LED bit offset.
       offset = (row << 1) + (cs / 8);
 
-      // Update state of LED in internal buffer.
-      if (state == LED_STATE::OFF)
-      {
-        // Clear bit for selected LED.
-        leds[offset] &= ~(0x01 << (cs % 8));
-      }
-      else
-      {
-        // Set bit for selected LED.
-        leds[offset] |= 0x01 << (cs % 8);
-      }
+      _setLEDState(offset, cs, state);
 
       WritePagedReg(PAGEDREGISTER::LEDONOFF, offset, leds[offset]);
     }
@@ -326,17 +321,7 @@ namespace IS31FL3733
         // Calculate LED bit offset.
         offset = (sw << 1) + (cs / 8);
 
-        // Update state of LED in internal buffer.
-        if (states[sw * CS_LINES + cs] == LED_STATE::OFF)
-        {
-          // Clear bit for selected LED.
-          leds[offset] &= ~(0x01 << (cs % 8));
-        }
-        else
-        {
-          // Set bit for selected LED.
-          leds[offset] |= 0x01 << (cs % 8);
-        }
+        _setLEDState(offset, cs, states[sw * CS_LINES + cs]);
       }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ void setup()
   Serial.println("Setting PWM state for all LEDs to half power");
   driver.SetLEDMatrixPWM(128);
 
-  Serial.println("Turning on all LEDs");
+  Serial.println("Setting state of all LEDs to ON");
   driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-
 #include <Arduino.h>
 #include <Wire.h>
 
@@ -9,7 +8,7 @@ using namespace IS31FL3733;
 // Arduino pin for the SDB line which is set high to enable the IS31FL3733 chip.
 const uint8_t SDB_PIN = 4;
 // Arduino pin for the IS13FL3733 interrupt pin.
-const uint8_t INTB_PIN = 7;
+const uint8_t INTB_PIN = 3;
 
 // Function prototypes for the read and write functions defined later in the file.
 uint8_t i2c_read_reg(const uint8_t i2c_addr, const uint8_t reg_addr, uint8_t *buffer, const uint8_t length);
@@ -60,22 +59,22 @@ uint8_t i2c_read_reg(const uint8_t i2c_addr, const uint8_t reg_addr, uint8_t *bu
 }
 
 /**
- * @brief Writes a buffer to the specified register.
+ * @brief Writes a buffer to the specified register. It is up to the caller to ensure the count of
+ * bytes to write doesn't exceed 31, which is the Arduino's write buffer size (32) minus one byte for
+ * the register address.
  * 
  * @param i2c_addr I2C address of the device to write the data to.
  * @param reg_addr Address of the register to write to.
  * @param buffer Pointer to an array of bytes to write.
  * @param count Number of bytes in the buffer.
- * @return uint8_t The number of bytes written.
+ * @return uint8_t 0 if success, non-zero on error.
  */
 uint8_t i2c_write_reg(const uint8_t i2c_addr, const uint8_t reg_addr, const uint8_t *buffer, const uint8_t count)
 {
   Wire.beginTransmission(i2c_addr);
   Wire.write(reg_addr);
-  byte bytesWritten = Wire.write(buffer, count);
-  Wire.endTransmission();
-
-  return bytesWritten;
+  Wire.write(buffer, count);
+  return Wire.endTransmission();
 }
 
 /**
@@ -122,11 +121,20 @@ void setup()
   Serial.println("Setting global current control to half");
   driver.SetGCC(127);
 
-  Serial.println("Setting PWM state for all LEDs to full power");
-  driver.SetLEDPWM(CS_LINES, SW_LINES, 255);
+  Serial.println("Setting PWM state for all LEDs to full power in 5 seconds...");
+  delay(5000);
+  driver.SetLEDMatrixPWM(255);
+  Serial.println("Done");
+  delay(5000);
+
+  Serial.println("Setting PWM state for all LEDs to half power in 5 seconds...");
+  delay(5000);
+  driver.SetLEDMatrixPWM(128);
+  Serial.println("Done");
+  delay(5000);
 
   Serial.println("Turning on all LEDs");
-  driver.SetLEDState(CS_LINES, SW_LINES, LED_STATE::ON);
+  driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");
   driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,23 +121,14 @@ void setup()
   Serial.println("Setting global current control to half");
   driver.SetGCC(127);
 
-  Serial.println("Setting PWM state for all LEDs to full power in 5 seconds...");
-  delay(5000);
-  driver.SetLEDMatrixPWM(255);
-  Serial.println("Done");
-  delay(5000);
-
-  Serial.println("Setting PWM state for all LEDs to half power in 5 seconds...");
-  delay(5000);
+  Serial.println("Setting PWM state for all LEDs to half power");
   driver.SetLEDMatrixPWM(128);
-  Serial.println("Done");
-  delay(5000);
 
   Serial.println("Turning on all LEDs");
   driver.SetLEDMatrixState(LED_STATE::ON);
 
   Serial.println("Configure all LEDs for ABM1");
-  driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::ABM1);
+  driver.SetLEDMatrixMode(LED_MODE::ABM1);
 
   ABM_CONFIG ABM1;
 
@@ -191,7 +182,7 @@ void loop()
     {
       Serial.println("ABM1 completed");
       Serial.println("Configure all LEDs for full on");
-      driver.SetLEDMode(CS_LINES, SW_LINES, LED_MODE::PWM);
+      driver.SetLEDMatrixMode(LED_MODE::PWM);
 
       ledState = LedState::LEDOn;
     }


### PR DESCRIPTION
Fixes #23
Fixes #25

Massive refactoring to remove all of the giant if statements and break things into specific methods.

Use memset where possible.

Write to I2C in as large a stream of data as possible given the platform to cutdown on time it takes to execute commands.

This set of changes is breaking and will require releasing a v2 of the library.